### PR TITLE
Update references after transferring to the trinodb org

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -54,8 +54,11 @@ jobs:
           ./bin/reports.sh reports/pr/index.md "Trino PR Reports" sql/pr/{idents,burndown,authors-per-month,changes-per-month,prs-per-author,reviewers-per-pr,reviews-per-author-assoc,top-reviewers,top-authors,top-mergers,sith-lords,mergers-authors,reviewers-top-authors,time-to-merge,time-to-merge-per-size,avg-time-to-merge,time-to-first-review,avg-time-to-first-review,reviewer-responsiveness,author-responsiveness,open-pr-age,awaiting-review,inactivity-on-prs,abandoned-prs,running-prs,stale-prs}.sql
       - name: Commit report
         run: |
-          git config --global user.name 'Jan Was'
-          git config --global user.email 'nineinchnick@users.noreply.github.com'
+          # pull in case someone pushed commits during reports generation, which can take a while
+          # if there are conflicts, this will fail
+          git pull --ff-only
+          git config user.name 'GitHub Automation'
+          git config user.email ''
           git add --all reports/
           git commit -m "Automated report"
           git push

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo is an example of using Trino to perform ETL (extract, transform, and l
 and generate basic reports. The complete workflow is:
 
 1. Use [a custom connector](https://github.com/nineinchnick/trino-rest) to read Github's API data and save it into an S3 bucket.
-1. Run some [queries](https://github.com/nineinchnick/trino-cicd/blob/master/sql) to analyze the data stored in the S3 bucket, save results to a file and publish it to [Github Pages](https://nineinchnick.github.io/trino-cicd/reports/).
+1. Run some [queries](https://github.com/trinodb/trino-cicd/blob/master/sql) to analyze the data stored in the S3 bucket, save results to a file and publish it to [Github Pages](https://trinodb.github.io/trino-cicd/reports/).
 
 All the of the above is repeatable and executed on a schedule using Github Actions.
 
@@ -57,11 +57,11 @@ trino --server localhost:8080 --catalog trinocicd --schema v2 --output-format=AL
 
 ## Sync
 
-[The sync workflow](https://github.com/nineinchnick/trino-cicd/blob/master/.github/workflows/sync.yml):
+[The sync workflow](https://github.com/trinodb/trino-cicd/blob/master/.github/workflows/sync.yml):
 1. Downloads and extracts a zip with the custom `trino-rest` connector.
 1. Starts Trino in a container with both this additional connector (plugin)
-   and its [configuration](https://github.com/nineinchnick/trino-cicd/blob/master/catalog/github.properties) mounted as volumes.
-   It also includes [configuration](https://github.com/nineinchnick/trino-cicd/blob/master/catalog/hive.properties) for a built-in connector
+   and its [configuration](https://github.com/trinodb/trino-cicd/blob/master/catalog/github.properties) mounted as volumes.
+   It also includes [configuration](https://github.com/trinodb/trino-cicd/blob/master/catalog/hive.properties) for a built-in connector
    that can read and write to an S3 bucket. The required credentials are passed
    as environmental variables, populated from Github Secrets.
 1. It runs a series of queries similar to `INSERT INTO hive.<table> SELECT * FROM github.<table>`
@@ -70,7 +70,7 @@ trino --server localhost:8080 --catalog trinocicd --schema v2 --output-format=AL
 
 ## Reports
 
-[The reports workflow](https://github.com/nineinchnick/trino-cicd/blob/master/.github/workflows/reports.yml):
+[The reports workflow](https://github.com/trinodb/trino-cicd/blob/master/.github/workflows/reports.yml):
 1. Starts Trino in a container with only the connector required to read data from the S3 bucket.
 1. Executes multiple [queries](/sql), saving results as a simple text table in a file.
-1. Commits the updated results file to this repository, which triggers publishing it to [Github Pages](https://nineinchnick.github.io/trino-cicd/reports/).
+1. Commits the updated results file to this repository, which triggers publishing it to [Github Pages](https://trinodb.github.io/trino-cicd/reports/).


### PR DESCRIPTION
We also need to update the link in the About section:
![image](https://github.com/user-attachments/assets/e728e000-313f-4a73-a966-d56ef085de5a)
